### PR TITLE
fix C++ compilation error

### DIFF
--- a/src/Geoid.hpp
+++ b/src/Geoid.hpp
@@ -124,7 +124,7 @@ namespace GeographicLib {
       _file.seekg(
 #if !(defined(__GNUC__) && __GNUC__ < 4)
                   // g++ 3.x doesn't know about the cast to streamoff.
-                  std::ios::streamoff
+                  std::streamoff
 #endif
                   (_datastart +
                    pixel_size_ * (unsigned(iy)*_swidth + unsigned(ix))));


### PR DESCRIPTION
Reproduce the error (requires a recent compiler):
```
docker run --rm archlinux bash -c 'pacman -Sy --noconfirm python-pip base-devel libtiff; pip install srtm4'
```

Reproduce the fix:
```
docker run --rm archlinux bash -c 'pacman -Sy --noconfirm python-pip base-devel git libtiff; pip install git+https://github.com/kidanger/srtm4.git@fix-compilation-streamoff'
docker run --rm python:3.9 bash -c 'pip install git+https://github.com/kidanger/srtm4.git@fix-compilation-streamoff'
```