### PR TITLE
pyproj: Fix rasterio conflict

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ requirements = ['filelock',
 
 extras_require = {
         'test': ['pytest>=4.6', 'pytest-cov'],
-        'crop': ['rasterio', 'pyproj>=3.0', 'affine'],
+        'crop': ['rasterio', 'pyproj>=3.0,<=3.3.1', 'affine'],
 }
 
 setup(name="srtm4",


### PR DESCRIPTION
It seems that in the pyproj versions>=3.4.0, our code to automatically download the transform grid on the network and apply it for geiod to ellipsoid conversion fails (You can check it in the tests/test_raster.py where ellipsoid test fails). So a simple solution for now is to avoid these versions. In the future, we should remove the pyproj dependency or include the geiod pyproj-compatible raster in srtm4.