### PR TITLE
use github actions to run tests and remove the upper-bound requirement on pyproj

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,23 @@
+name: tests
+
+on: [push, pull_request]
+
+jobs:
+
+  tests:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install srtm4
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[test,crop]"
+      - name: Run tests
+        run: |
+          pytest --cov=srtm4 --cov-report term-missing .

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,4 +21,5 @@ jobs:
           pip install -e ".[test,crop]"
       - name: Run tests
         run: |
+          pyproj sync -v --file us_nga_egm96_15
           pytest --cov=srtm4 --cov-report term-missing .

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,6 +7,7 @@ jobs:
   tests:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         python-version: ["3.7", "3.8", "3.9", "3.10"]
     steps:

--- a/README.md
+++ b/README.md
@@ -32,3 +32,7 @@ In a Python interpreter:
 In a shell:
 
     GEOID_PATH=data ./bin/srtm4 2 48
+
+For the `crop` function, if pyproj complains about the download of file, you can fix it manually with the command:
+
+    pyproj sync -v --file us_nga_egm96_15

--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 Download and parsing of SRTM4 elevation data.
 
-[![Build Status](https://travis-ci.com/cmla/srtm4.svg?branch=master)](https://travis-ci.com/cmla/srtm4)
 [![PyPI version](https://img.shields.io/pypi/v/srtm4)](https://pypi.org/project/srtm4)
 
 [Carlo de Franchis](mailto:carlo.de-franchis@cmla.ens-cachan.fr), Enric
@@ -10,8 +9,8 @@ Meinhardt, Gabriele Facciolo, CMLA 2018
 
 # Installation and dependencies
 
-The main source code repository for this project is https://github.com/cmla/srtm4.
-It is written in Python. It was tested with Python 3.5, 3.6 and 2.7.
+The main source code repository for this project is https://github.com/centreborelli/srtm4.
+It is written in Python. It is tested with Python 3.7, 3.8, 3.9 and 3.10.
 
 `srtm4` requires `libtiff` development files. They can be installed with
 `apt-get install libtiff-dev` (Ubuntu, Debian) or `brew install libtiff`

--- a/setup.py
+++ b/setup.py
@@ -36,8 +36,8 @@ requirements = ['filelock',
 
 
 extras_require = {
-        'test': ['pytest>=4.6', 'pytest-cov'],
-        'crop': ['rasterio', 'pyproj>=3.0,<=3.3.1', 'affine'],
+        'test': ['pytest', 'pytest-cov'],
+        'crop': ['rasterio', 'pyproj>=3.0', 'affine'],
 }
 
 setup(name="srtm4",

--- a/srtm4/__init__.py
+++ b/srtm4/__init__.py
@@ -7,7 +7,3 @@ try:
     from srtm4.raster import crop
 except ImportError:  # optional requirements were not installed
     pass
-except AttributeError:  # some optional requirements are available but don't
-                        # match the required version. E.g. pyproj < 3 triggers:
-                        # module 'pyproj' has no attribute 'network'
-    pass


### PR DESCRIPTION
`errcheck=True` will throw an exception instead of returning inf (but only when network mode is enabled unfortunately)